### PR TITLE
fixes MGDSTRM-5036: added secret SERVICE_PUBLIC_HOST_URL to avoid using default url

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -138,6 +138,7 @@ jobs:
           OCM_SERVICE_TOKEN: ${{ secrets.OCM_SERVICE_TOKEN }}
           VAULT_ACCESS_KEY: ${{ secrets.VAULT_ACCESS_KEY }}
           VAULT_SECRET_ACCESS_KEY: ${{ secrets.VAULT_SECRET_ACCESS_KEY }}
+          SERVICE_PUBLIC_HOST_URL: ${{ secrets.SERVICE_PUBLIC_HOST_URL }}
         run: |
           make deploy
           oc rollout restart deployment/cos-fleet-manager


### PR DESCRIPTION
## Description
Added env variable to deploy make target to use cluster specific fleet manager. 

## Verification Steps
1. Create addon parameters by calling /api/connector_mgmt/v1/kafka_connector_clusters/${1}/addon_parameters
2. Parameter control-plane-base-url must no be the default https://api.openshift.com

## Checklist (Definition of Done)
~~- [ ] All acceptance criteria specified in JIRA have been completed~~
~~- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
~~- [ ] Documentation added for the feature~~
~~- [ ] CI and all relevant tests are passing~~
~~- [ ] Code Review completed~~
~~- [ ] Verified independently by reviewer~~
~~- [ ] Required metrics/dashboards/alerts have been added (or PR created).~~
~~- [ ] Required Standard Operating Procedure (SOP) is added.~~
~~- [ ] JIRA has created for changes required on the client side~~