### PR TITLE
Added flag --keycloak-client-expire to templates/service-templates

### DIFF
--- a/templates/service-template.yml
+++ b/templates/service-template.yml
@@ -323,6 +323,10 @@ parameters:
   description: The type of vault to use to store secrets
   value: tmp
 
+- name: KEYCLOAK_CLIENT_EXPIRE
+  description: Whether or not to tag Keycloak created Client to expire in 2 hours (useful for cleaning up after integrations tests)
+  value: "false""
+
 objects:
   - kind: ConfigMap
     apiVersion: v1
@@ -596,6 +600,7 @@ objects:
             - --vault-kind=${VAULT_KIND}
             - --vault-secret-access-key-file=/secrets/service/vault.secretaccesskey
             - -v=${GLOG_V}
+            - --keycloak-client-expire=${KEYCLOAK_CLIENT_EXPIRE}
             resources:
               requests:
                 cpu: ${CPU_REQUEST}


### PR DESCRIPTION
## Description
this is linked to https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/659 and needed to disable keycloak clients expiration in integration environments.

## Verification Steps
1. once https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/659 is merged merge this one
2. verify that the github action CI deployment succeed

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] ~~Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
- [x] ~~Documentation added for the feature~~
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [x] ~~Required metrics/dashboards/alerts have been added (or PR created).~~
- [x] ~~Required Standard Operating Procedure (SOP) is added.~~
- [x] ~~JIRA has created for changes required on the client side~~