### PR TITLE
MGDCTRS-1819 Remove Debezium version from connector-type id field for RHOC Debezium connector-types

### DIFF
--- a/templates/connector-metadata-debezium-template.yaml
+++ b/templates/connector-metadata-debezium-template.yaml
@@ -18,6 +18,42 @@ objects:
     data:
       connector-metadata-debezium.yaml: |-
         ---
+        - id: debezium-mongodb
+          labels:
+            - source
+            - debezium
+            - mongodb
+            - category-database
+            - category-change-data-capture
+          annotations:
+            cos.bf2.org/pricing-tier: plus
+        - id: debezium-mysql
+          labels:
+            - source
+            - debezium
+            - mysql
+            - category-database
+            - category-change-data-capture
+          annotations:
+            cos.bf2.org/pricing-tier: plus
+        - id: debezium-postgres
+          labels:
+            - source
+            - debezium
+            - postgres
+            - category-database
+            - category-change-data-capture
+          annotations:
+            cos.bf2.org/pricing-tier: plus
+        - id: debezium-sqlserver
+          labels:
+            - source
+            - debezium
+            - sqlserver
+            - category-database
+            - category-change-data-capture
+          annotations:
+            cos.bf2.org/pricing-tier: plus
         - id: debezium-mongodb-1.9.6.Final
           labels:
             - source
@@ -54,46 +90,6 @@ objects:
             - debezium
             - sqlserver
             - 1.9.6.Final
-            - category-database
-            - category-change-data-capture
-          annotations:
-            cos.bf2.org/pricing-tier: plus
-        - id: debezium-mongodb-2.0.1.Final
-          labels:
-            - source
-            - debezium
-            - mongodb
-            - 2.0.1.Final
-            - category-database
-            - category-change-data-capture
-          annotations:
-            cos.bf2.org/pricing-tier: plus
-        - id: debezium-mysql-2.0.1.Final
-          labels:
-            - source
-            - debezium
-            - mysql
-            - 2.0.1.Final
-            - category-database
-            - category-change-data-capture
-          annotations:
-            cos.bf2.org/pricing-tier: plus
-        - id: debezium-postgres-2.0.1.Final
-          labels:
-            - source
-            - debezium
-            - postgres
-            - 2.0.1.Final
-            - category-database
-            - category-change-data-capture
-          annotations:
-            cos.bf2.org/pricing-tier: plus
-        - id: debezium-sqlserver-2.0.1.Final
-          labels:
-            - source
-            - debezium
-            - sqlserver
-            - 2.0.1.Final
             - category-database
             - category-change-data-capture
           annotations:


### PR DESCRIPTION
relates to https://issues.redhat.com/browse/MGDCTRS-1819
