### PR TITLE
[WIP] feat: add Observability Remote Write Proxy deployment templates

### DIFF
--- a/docs/deploying-observability-remote-write-proxy-in-openshift.md
+++ b/docs/deploying-observability-remote-write-proxy-in-openshift.md
@@ -1,0 +1,73 @@
+# Deploying Observability Remote Write Proxy in OpenShift
+
+This document explains how to configure and deploy Observability Remote Write
+Proxy [Observability Remote Write Proxy](https://github.com/bf2fc6cc711aee1a0c2a/observability-remote-write-proxy)
+in OpenShift.
+
+This document assumes that the reader is familiar with Observability
+Remote Write Proxy as well as with its configuration. For information about it please go to the
+[Observability Remote Write Proxy repository](https://github.com/bf2fc6cc711aee1a0c2a/observability-remote-write-proxy).
+
+## Configuring and Deploying Observability Remote Write Proxy
+
+To send metrics to Observatorium from the Data Plane side, using
+[Observability Remote Write Proxy](https://github.com/bf2fc6cc711aee1a0c2a/observability-remote-write-proxy)
+is required. This avoids needing to store Observatorium credentials in the
+Data Planes managed by COS Fleet Manager.
+
+Observability Remote Write Proxy is usually deployed together with the COS
+Fleet Manager deployment.
+
+The requirement is that the proxy needs to be reachable at network level by
+the Data Planes being managed.
+
+To configure and deploy Observability Remote Write Prox follow the next steps:
+
+If you want to enable Observability Remote Write Proxy OIDC Token Retrieval
+the OIDC configuration secret needs to be created. To do so execute:
+```sh
+make deploy/observability-remote-write-proxy/secrets OBSERVABILITY_REMOTE_WRITE_PROXY_OIDC_CONFIG_FILEPATH=<file-containing-obsrwproxy-config>
+```
+
+Where OBSERVABILITY_REMOTE_WRITE_PROXY_OIDC_CONFIG_FILEPATH contains the
+Observability Remote Write Proxy OIDC configuration file. See a
+[sample Observability Remote Write Proxy OIDC configuration file](https://github.com/bf2fc6cc711aee1a0c2a/observability-remote-write-proxy/blob/main/secrets/oidc-config.yaml.sample) to see the available attributes.
+
+Then, an OpenShift route to expose the Observability Remote Write Proxy has to
+be created. To do so, execute the following command:
+```sh
+make deploy/observability-remote-write-proxy/route
+```
+
+Finally, deploy the Observability Remote Write Proxy by running:
+```sh
+make deploy/observability-remote-write-proxy \
+  OBSERVABILITY_REMOTE_WRITE_PROXY_FORWARD_URL=<proxy-forward-url>
+  OBSERVABILITY_REMOTE_WRITE_PROXY_OIDC_ENABLED=<bool>
+  OBSERVABILITY_REMOTE_WRITE_PROXY_TOKEN_VERIFICATION_ENABLED=<bool>
+  OBSERVABILITY_REMOTE_WRITE_PROXY_TOKEN_VERIFICATION_URL=<token-verification-url>
+```
+
+The description of the previously shown parameters are:
+* OBSERVABILITY_REMOTE_WRITE_PROXY_FORWARD_URL: URL of a Prometheus Remote
+  Write Receiver Endpoint to which requests of the Observability Remote Write
+  Proxy will be forwarded to after they are successfully verified. The
+  Observatorium Remote Write endpoint URL can be used as a value here.
+* OBSERVABILITY_REMOTE_WRITE_PROXY_OIDC_ENABLED: Enables OIDC token retrieval.
+  If enabled, the retrieved OIDC token is provided when
+  Observability Remote Write Proxy forwards the request to the
+  Prometheus Remote Write Receiver Endpoint specified in
+  OBSERVABILITY_REMOTE_WRITE_PROXY_FORWARD_URL.
+* OBSERVABILITY_REMOTE_WRITE_PROXY_TOKEN_VERIFICATION_ENABLED: Enables Token
+  verification on requests that arrive to the Observability Remote Write Proxy.
+  If enabled, Observability Remote Write Proxy performs
+  verification of the token provided as part of the 'Authorization' HTTP
+  Header of the requests that receives by using
+  OBSERVABILITY_REMOTE_WRITE_PROXY_TOKEN_VERIFICATION_URL
+* OBSERVABILITY_REMOTE_WRITE_PROXY_TOKEN_VERIFICATION_URL: URL endpoint used as
+  part of the Token Verification on requests that arrive to the Observability
+  Remote Write Proxy.
+  If OBSERVABILITY_REMOTE_WRITE_PROXY_TOKEN_VERIFICATION_ENABLED is enabled
+  it must be set and not empty
+
+After this, an Observability Remote Write Proxy should be up and running.

--- a/templates/observability-remote-write-proxy-oidc-secret.yml
+++ b/templates/observability-remote-write-proxy-oidc-secret.yml
@@ -1,0 +1,23 @@
+---
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: observability-remote-write-proxy-oidc-secret
+  annotations:
+    description: "Observability Remote Write Proxy OIDC secret"
+objects:
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: observability-remote-write-proxy-oidc-config
+  data:
+    oidc-config: "${OBSERVABILITY_REMOTE_WRITE_PROXY_OIDC_CONFIG}"
+
+parameters:
+- name: OBSERVABILITY_REMOTE_WRITE_PROXY_OIDC_CONFIG
+  description: >-
+    Base64 encoded Observability Remote Write Proxy OIDC configuration.
+    It should contain the YAML contents. See
+    https://github.com/bf2fc6cc711aee1a0c2a/observability-remote-write-proxy
+    for details on the configuration format.
+  required: true

--- a/templates/observability-remote-write-proxy-route.yml
+++ b/templates/observability-remote-write-proxy-route.yml
@@ -1,0 +1,22 @@
+# This file contains an OpenShift template that creates a route helping to
+# directly access the Observability Remote Write Proxy in the
+# development environment.
+---
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: observability-remote-write-proxy-route
+objects:
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    name: observability-rw-proxy
+    labels:
+      app.kubernetes.io/name: observability-remote-write-proxy
+  spec:
+    to:
+      kind: Service
+      name: observability-rw-proxy
+    tls:
+      termination: edge
+      insecureEdgeTerminationPolicy: Redirect

--- a/templates/observability-remote-write-proxy.yml
+++ b/templates/observability-remote-write-proxy.yml
@@ -1,0 +1,371 @@
+---
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: observability-remote-write-proxy
+  annotations:
+    description: "Prometheus Remote Write Proxy for Observability"
+objects:
+  - kind: Deployment
+    apiVersion: apps/v1
+    metadata:
+      labels:
+        app.kubernetes.io/component: prometheus-remote-write-proxy
+        app.kubernetes.io/name: observability-remote-write-proxy
+        app.kubernetes.io/version: ${OBSERVABILITY_REMOTE_WRITE_PROXY_IMAGE_TAG}
+      name: observability-remote-write-proxy
+    spec:
+      replicas: ${{OBSERVABILITY_REMOTE_WRITE_PROXY_REPLICAS}}
+      strategy:
+        rollingUpdate:
+          maxSurge: 25%
+          maxUnavailable: 25%
+        type: RollingUpdate
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: prometheus-remote-write-proxy
+          app.kubernetes.io/name: observability-remote-write-proxy
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/component: prometheus-remote-write-proxy
+            app.kubernetes.io/name: observability-remote-write-proxy
+        spec:
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          affinity:
+            # Prefer not co-locating Observability Remote Write Proxy pods in the
+            # same zone. This means that K8s scheduler will try to spread
+            # the different Observability Remote Write Proxy pods among the
+            # available zones (logical failure domains)
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: app.kubernetes.io/name
+                      operator: In
+                      values:
+                      - observability-remote-write-proxy
+                  topologyKey: topology.kubernetes.io/zone
+                weight: 100
+          containers:
+          - name: observability-remote-write-proxy
+            image: ${OBSERVABILITY_REMOTE_WRITE_PROXY_IMAGE_NAME}:${OBSERVABILITY_REMOTE_WRITE_PROXY_IMAGE_TAG}
+            imagePullPolicy: ${OBSERVABILITY_REMOTE_WRITE_PROXY_IMAGE_PULL_POLICY}
+            ports:
+            - containerPort: ${{OBSERVABILITY_REMOTE_WRITE_PROXY_PORT}}
+              name: http
+            - containerPort: ${{OBSERVABILITY_REMOTE_WRITE_PROXY_METRICS_PORT}}
+              name: metrics
+            command:
+              - /proxy
+              - --proxy.listen.port=${OBSERVABILITY_REMOTE_WRITE_PROXY_PORT}
+              - --proxy.metrics.port=${OBSERVABILITY_REMOTE_WRITE_PROXY_METRICS_PORT}
+              - --proxy.forwardUrl=${OBSERVABILITY_REMOTE_WRITE_PROXY_FORWARD_URL}
+              - --oidc.enabled=${OBSERVABILITY_REMOTE_WRITE_PROXY_OIDC_ENABLED}
+              - --oidc.filename=${OBSERVABILITY_REMOTE_WRITE_PROXY_OIDC_CONFIG_FILEDIR}/${OBSERVABILITY_REMOTE_WRITE_PROXY_OIDC_CONFIG_FILENAME}
+              - --token.verification.enabled=${OBSERVABILITY_REMOTE_WRITE_PROXY_TOKEN_VERIFICATION_ENABLED}
+              - --token.verification.url=${OBSERVABILITY_REMOTE_WRITE_PROXY_TOKEN_VERIFICATION_URL}
+              - --token.verification.cacert.filename=${OBSERVABILITY_REMOTE_WRITE_PROXY_TOKEN_VERIFICATION_SERVICE_SERVING_CA_FILEDIR}/${OBSERVABILITY_REMOTE_WRITE_PROXY_TOKEN_VERIFICATION_SERVICE_SERVING_CA_FILENAME}
+              - --token.verification.cacert.enabled=${OBSERVABILITY_REMOTE_WRITE_PROXY_TOKEN_VERIFICATION_SERVICE_SERVING_CA_ENABLED}
+            resources:
+              requests:
+                cpu: ${{OBSERVABILITY_REMOTE_WRITE_PROXY_CPU_RESOURCE_REQUESTS}}
+                memory: ${{OBSERVABILITY_REMOTE_WRITE_PROXY_MEMORY_RESOURCE_REQUESTS}}
+              limits:
+                cpu: ${{OBSERVABILITY_REMOTE_WRITE_PROXY_CPU_RESOURCE_LIMITS}}
+                memory: ${{OBSERVABILITY_REMOTE_WRITE_PROXY_MEMORY_RESOURCE_LIMITS}}
+            readinessProbe:
+              httpGet:
+                path: /healthcheck
+                port: ${{OBSERVABILITY_REMOTE_WRITE_PROXY_PORT}}
+                scheme: HTTP
+                httpHeaders:
+                - name: User-Agent
+                  value: Probe
+              initialDelaySeconds: 5
+              periodSeconds: 10
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+            volumeMounts:
+            - name: observability-remote-write-proxy-oidc-config
+              mountPath: ${OBSERVABILITY_REMOTE_WRITE_PROXY_OIDC_CONFIG_FILEDIR}
+            - name: observability-remote-write-proxy-service-serving-ca
+              mountPath: ${OBSERVABILITY_REMOTE_WRITE_PROXY_TOKEN_VERIFICATION_SERVICE_SERVING_CA_FILEDIR}
+          volumes:
+           - name: observability-remote-write-proxy-oidc-config
+             secret:
+               secretName: observability-remote-write-proxy-oidc-config
+               defaultMode: 288 # 0440 in octal mode permissions
+               optional: true
+           - name: observability-remote-write-proxy-service-serving-ca
+             configMap:
+               name: observability-remote-write-proxy-service-serving-ca
+               defaultMode: 288 # 0440 in octal mode permissions
+               optional: true
+  - kind: Service
+    apiVersion: v1
+    metadata:
+      labels:
+        app.kubernetes.io/component: prometheus-remote-write-proxy
+        app.kubernetes.io/name: observability-remote-write-proxy
+      name: observability-rw-proxy
+    spec:
+      ports:
+        - name: http
+          port: ${{OBSERVABILITY_REMOTE_WRITE_PROXY_PORT}}
+          targetPort: ${{OBSERVABILITY_REMOTE_WRITE_PROXY_PORT}}
+          protocol: TCP
+      selector:
+        app.kubernetes.io/component: prometheus-remote-write-proxy
+        app.kubernetes.io/name: observability-remote-write-proxy
+  - kind: Service
+    apiVersion: v1
+    metadata:
+      labels:
+        app.kubernetes.io/component: prometheus-remote-write-proxy-metrics
+        app.kubernetes.io/name: observability-remote-write-proxy-metrics
+      name: observability-rw-proxy-metrics
+    spec:
+      ports:
+        - name: metrics
+          port: ${{OBSERVABILITY_REMOTE_WRITE_PROXY_METRICS_PORT}}
+          targetPort: ${{OBSERVABILITY_REMOTE_WRITE_PROXY_METRICS_PORT}}
+          protocol: TCP
+      selector:
+        app.kubernetes.io/component: prometheus-remote-write-proxy
+        app.kubernetes.io/name: observability-remote-write-proxy
+  - kind: PodDisruptionBudget
+    apiVersion: policy/v1
+    metadata:
+      name: observability-remote-write-proxy-pdb
+    spec:
+      minAvailable: ${{OBSERVABILITY_REMOTE_WRITE_PROXY_PDB_MIN_AVAILABLE}}
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: observability-remote-write-proxy
+  - kind: ConfigMap
+    apiVersion: v1
+    metadata:
+      # This ConfigMap contains the Cluster's Service CA certificate, which
+      # issues the Service certificates.
+      # The CA certificate is automatically stored in the ConfigMap
+      # by using the `service.beta.openshift.io/inject-cabundle` K8s annotation
+      # set to true.
+      # The ConfigMap key name corresponding to the stored CA certificate
+      # is `service-ca.crt`.
+      # The CA cert is valid for 26 months and is automatically rotated
+      # when there is less than 13 months validity left. After rotation, the
+      # previous service CA configuration is still trusted until its expiration.
+      # This allows a grace period for all affected services to refresh their
+      # key material before the expiration. If you do not upgrade your cluster
+      # during this grace period, which restarts services and refreshes
+      # their key material, you might need to manually restart services
+      # to avoid failures after the previous service CA expires.
+      name: observability-remote-write-proxy-service-serving-ca
+      annotations:
+        qontract.recycle: "true"
+        service.beta.openshift.io/inject-cabundle: "true"
+
+parameters:
+- name: OBSERVABILITY_REMOTE_WRITE_PROXY_IMAGE_NAME
+  description: Observability Remote Write Proxy container image name
+  value: "quay.io/rhoas/observability-remote-write-proxy"
+
+- name: OBSERVABILITY_REMOTE_WRITE_PROXY_IMAGE_TAG
+  description: Observability Remote Write Proxy container image tag
+  value: "latest"
+
+- name: OBSERVABILITY_REMOTE_WRITE_PROXY_IMAGE_PULL_POLICY
+  description: >-
+    Observability Remote Write Proxy container image pull policy.
+    Accepted values: ['Always', 'IfNotPresent', 'Never']"
+  value: "Always"
+
+- name: OBSERVABILITY_REMOTE_WRITE_PROXY_REPLICAS
+  description: >-
+    Number of replicas of the Observability Remote Write Proxy K8s Deployment
+  value: "1"
+
+- name: OBSERVABILITY_REMOTE_WRITE_PROXY_PORT
+  description: >-
+    Port number used to configure the Observability Remote Write Proxy
+    endpoint and associated K8s Service
+  value: "8080"
+
+- name: OBSERVABILITY_REMOTE_WRITE_PROXY_METRICS_PORT
+  description: >-
+    Port number used to configure the Observability Remote Write Proxy
+    Prometheus metrics endpoint and associated K8s Service
+  value: "9090"
+
+- name: OBSERVABILITY_REMOTE_WRITE_PROXY_OIDC_ENABLED
+  description: >-
+    Enables OIDC token retrieval. If set to true, the provided
+    OIDC ClientID/Secret pair configured in the file pointed by
+    OBSERVABILITY_REMOTE_WRITE_PROXY_OIDC_CONFIG_FILEDIR/OBSERVABILITY_REMOTE_WRITE_PROXY_OIDC_CONFIG_FILEPATH
+    is used to retrieve an OIDC token from the OIDC token
+    endpoint, which is also specified in the file pointed by
+    OBSERVABILITY_REMOTE_WRITE_PROXY_OIDC_CONFIG_FILEDIR/OBSERVABILITY_REMOTE_WRITE_PROXY_OIDC_CONFIG_FILEPATH.
+    Then, the retrieved OIDC token is provided when
+    Observability Remote Write Proxy forwards the request to the
+    Prometheus Remote Write Receiver Endpoint specified in
+    OBSERVABILITY_REMOTE_WRITE_PROXY_FORWARD_URL
+  value: "true"
+
+- name: OBSERVABILITY_REMOTE_WRITE_PROXY_OIDC_CONFIG_FILEDIR
+  description: >-
+    Directory in the Observability Remote Write Proxy container's filesystem
+    that contains the OIDC configuration file.
+    The value must be a directory and must not contain the file name.
+    See https://github.com/bf2fc6cc711aee1a0c2a/observability-remote-write-proxy
+    for details on the configuration format.
+    Only takes effect when OBSERVABILITY_REMOTE_WRITE_PROXY_OIDC_ENABLED
+    is "true".
+    Required when OBSERVABILITY_REMOTE_WRITE_PROXY_OIDC_ENABLED
+    is "true"
+  value: "/obs-rw-proxy-oidc-config"
+
+- name: OBSERVABILITY_REMOTE_WRITE_PROXY_OIDC_CONFIG_FILENAME
+  description: >-
+    File name within the directory specified in
+    OBSERVABILITY_REMOTE_WRITE_PROXY_OIDC_CONFIG_FILEDIR where to find the
+    Observability Remote Write Proxy OIDC configuration.
+    The value must be a file name and not a path.
+    Only takes effect when OBSERVABILITY_REMOTE_WRITE_PROXY_OIDC_ENABLED
+    is "true".
+    Required when OBSERVABILITY_REMOTE_WRITE_PROXY_OIDC_ENABLED
+    is "true".
+    See https://github.com/bf2fc6cc711aee1a0c2a/observability-remote-write-proxy
+    for details on the configuration format.
+    Only takes effect when OBSERVABILITY_REMOTE_WRITE_PROXY_OIDC_ENABLED
+    is "true".
+    Required when OBSERVABILITY_REMOTE_WRITE_PROXY_OIDC_ENABLED
+    is "true"
+  value: "oidc-config"
+
+- name: OBSERVABILITY_REMOTE_WRITE_PROXY_FORWARD_URL
+  description: >-
+    URL of a Prometheus Remote Write Receiver Endpoint to which requests of the
+    Observability Remote Write Proxy will be forwarded to after they
+    are successfully verified
+  required: true
+
+- name: OBSERVABILITY_REMOTE_WRITE_PROXY_TOKEN_VERIFICATION_ENABLED
+  description: >-
+    Enables Token verification on requests that arrive to the Observability
+    Remote Write Proxy.
+    If enabled, Observability Remote Write Proxy performs
+    verification of the token provided as part of the 'Authorization' HTTP
+    Header of the requests that receives.
+    The verification that is performed is that a request is authorized
+    if the call to the OBSERVABILITY_REMOTE_WRITE_PROXY_TOKEN_VERIFICATION_URL
+    URL with the '/<cluster_id>' suffix appended returns a
+    HTTP 200 Status Code. <cluster_id> is part of the information
+    provided in the HTTP Body of the request to Observability
+    Remote Write Proxy.
+    The provided token that is received by Observability Remote Write Proxy
+    is used for the request to
+    OBSERVABILITY_REMOTE_WRITE_PROXY_TOKEN_VERIFICATION_URL/<cluster_id> but
+    the token itself is not verified in Observability Remote Write Proxy.
+    Requests to the /healthcheck URL path are not Token verified
+  value: "true"
+
+- name: OBSERVABILITY_REMOTE_WRITE_PROXY_TOKEN_VERIFICATION_URL
+  description: >-
+    URL endpoint used as part of the Token Verification on requests that arrive to
+    the Observability Remote Write Proxy. The '/<cluster_id>' suffix is appended
+    to the provided URL, where <cluster_id> is part of the information
+    provided in the HTTP Body of the request to Observability Remote Write Proxy.
+    See the description of the
+    OBSERVABILITY_REMOTE_WRITE_PROXY_TOKEN_VERIFICATION_ENABLED parameter for
+    more information about details of the verification.
+    Only takes effect when OBSERVABILITY_REMOTE_WRITE_PROXY_TOKEN_VERIFICATION_ENABLED
+    is "true".
+    Required when OBSERVABILITY_REMOTE_WRITE_PROXY_TOKEN_VERIFICATION_ENABLED
+    is "true"
+
+- name: OBSERVABILITY_REMOTE_WRITE_PROXY_TOKEN_VERIFICATION_SERVICE_SERVING_CA_ENABLED
+  description: >-
+    If set to true, the provided Service Serving CA certificate
+    specified in the file pointed by
+    OBSERVABILITY_REMOTE_WRITE_PROXY_TOKEN_VERIFICATION_SERVICE_SERVING_CA_FILEDIR/OBSERVABILITY_REMOTE_WRITE_PROXY_TOKEN_VERIFICATION_SERVICE_SERVING_CA_FILENAME
+    is appended to the system's certificate trusted store when token verification
+    is performed. See OBSERVABILITY_REMOTE_WRITE_PROXY_TOKEN_VERIFICATION_ENABLED
+    for details on token verification.
+    The Serivce Serving CA certificate has to be a X.509 certificate encoded
+    in PEM format.
+    Only takes effect when OBSERVABILITY_REMOTE_WRITE_PROXY_TOKEN_VERIFICATION_ENABLED
+    is set to true.
+  value: "false"
+
+- name: OBSERVABILITY_REMOTE_WRITE_PROXY_TOKEN_VERIFICATION_SERVICE_SERVING_CA_FILEDIR
+  description: >-
+    Directory in the Observability Remote Write Proxy container's filesystem
+    that contains the Service Service CA certificate.
+    The value must be a directory and must not contain the file name.
+    Only takes effect when
+    OBSERVABILITY_REMOTE_WRITE_PROXY_TOKEN_VERIFICATION_SERVICE_SERVING_CA_ENABLED
+    is "true".
+    Required when OBSERVABILITY_REMOTE_WRITE_PROXY_TOKEN_VERIFICATION_SERVICE_SERVING_CA_ENABLED
+    is "true"
+  value: "/obs-rw-proxy-service-serving-ca"
+
+- name: OBSERVABILITY_REMOTE_WRITE_PROXY_TOKEN_VERIFICATION_SERVICE_SERVING_CA_FILENAME
+  description: >-
+    File name within the directory specified in
+    OBSERVABILITY_REMOTE_WRITE_PROXY_TOKEN_VERIFICATION_SERVICE_SERVING_CA_FILEDIR
+    where to find the Service Service CA certificate.
+    The value must be a file name and not a path.
+    Only takes effect when OBSERVABILITY_REMOTE_WRITE_PROXY_TOKEN_VERIFICATION_SERVICE_SERVING_CA_ENABLED
+    is "true".
+    Required when OBSERVABILITY_REMOTE_WRITE_PROXY_TOKEN_VERIFICATION_SERVICE_SERVING_CA_ENABLED
+    is "true".
+  value: "service-ca.crt"
+
+- name: OBSERVABILITY_REMOTE_WRITE_PROXY_PDB_MIN_AVAILABLE
+  description: >-
+    Configures the 'minAvailable' attribute of the PodDisruptionBudget
+    associated to the Observability Remote Write Proxy K8s Deployment. An
+    eviction is allowed if at least 'minAvailable' will still be available
+    after the eviction, i.e. even in the absence of the evicted pod. It can
+    be a number or a percentage (e.g. '50%')
+  value: "1"
+
+- name: OBSERVABILITY_REMOTE_WRITE_PROXY_MEMORY_RESOURCE_REQUESTS
+  description: >-
+    Memory K8s Resource Requests for the Observability Remote Write Proxy.
+    This parameter can be set to "null" to unset the Memory Resource Requests.
+    See https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
+    for details on the accepted values.
+  value: "128Mi"
+
+- name: OBSERVABILITY_REMOTE_WRITE_PROXY_MEMORY_RESOURCE_LIMITS
+  description: >-
+    Memory K8s Resource Limits for the Observability Remote Write Proxy.
+    This parameter can be set to "null" to unset the Memory Resource Limits.
+    See https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
+    for details on the accepted values.
+  value: "1Gi"
+
+- name: OBSERVABILITY_REMOTE_WRITE_PROXY_CPU_RESOURCE_REQUESTS
+  description: >-
+    CPU K8s Resource Requests for the Observability Remote Write Proxy.
+    This parameter can be set to "null" to unset the CPU Resource Limits.
+    See https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
+    for details on the accepted values.
+  value: "200m"
+
+- name: OBSERVABILITY_REMOTE_WRITE_PROXY_CPU_RESOURCE_LIMITS
+  description: >-
+    CPU K8s Resource Limits for the Observability Remote Write Proxy.
+    This parameter can be set to "null" to unset the CPU Resource Limits.
+    See https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
+    for details on the accepted values.
+  value: "null"


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->
## Description

Related to https://issues.redhat.com/browse/MGDSTRM-11146.

This PR adds the OCP templates needed to deploy [Observability Remote Write Proxy](https://github.com/bf2fc6cc711aee1a0c2a/observability-remote-write-proxy).

The aim of Observability Remote Write Proxy in COS Fleet Manager context is for the related Prometheus metrics in the Data Planes to be sent to Observatorium indirectly through the proxy.
The motivation of sending the credentials indirectly through the proxy is to avoid needing to store Observatorium credentials in the Data Planes themselves.

This PR adds the following OCP templates:
* `templates/observability-remote-write-proxy-oidc-secret.yml`: Contains the needed K8s secret when OIDC token retrieval is enabled in Observability Remote Write Proxy.
* `templates/observability-remote-write-proxy-route.yml`: Contains an OCP Route used to access the Observability Remote Write Proxy API. This route is intended for development purposes only.
* `templates/observability-remote-write-proxy.yml`: Contains the Observability Remote Write Proxy K8s Deployment and related K8s objects like K8s Service, PodDisruptionBudget, ...

The templates have been intentionally been implemented separatedly from templates/service-template.yml, templates/secret-template.yml and templates/route-template.yml. The reason for that is that the Observability Remote Write Proxy is considered independent of the COS Fleet Manager deployment and its related elements themselves.

Aside from the templates, other changes made have been:
* Add Makefile targets to allow deploying Observability Remote Write Proxy more easily during development
* Add documentation around deploying Observability Remote Write Proxy in OpenShift

Once this is merged some additional tasks will be needed on AppInterface side to be able to use Observability Remote Write Proxy in the stage and production environments. This includes the creation of additional OCP routes dedicated to it

## Verification Steps

Deploy Observability Remote Write Proxy and configure COS Fleet Manager to use it.
To do that:
1. Deploy Observability Remote Write Proxy in OCP. Read the documentation of this PR on how to do it. Additionally, temporarily edit the OCP template to use the `3d31c44` container image tag to get the latest functionality. Observatorium Stage can be used when setting the Observatorium related information. If there are any doubts about what values to set on some steps please let me know. Be careful with the metric name and labels being sent in that case as the metrics namespacing is shared and you don't want unintentional overwritting of metrics
2. Configure COS Fleet Manager to use Observability Remote Write Proxy. To do so, run COS Fleet Manager with the `--observability-red-hat-sso-observatorium-gateway` flag set to the URL provided by the OCP Route created for Observability Remote Write Proxy. The URL scheme has to be included as part of the URL. An Observability Operator version that includes the latest functionality that allows it to use Observability Remote Write Proxy has to be used
3. Verify that metrics are being sent to Observatorium through Observability Remote Write Proxy


<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Required metrics/dashboards/alerts have been added (or PR created).
- [ ] Required Standard Operating Procedure (SOP) is added.
- [ ] JIRA has created for changes required on the client side